### PR TITLE
Add custom port setting

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -9,6 +9,10 @@ module.exports =
       title: "psc-ide executable location"
       type: 'string'
       default: process.env.HOME + '/.local/bin/psc-ide'
+    pscIdePort:
+      title: "psc-ide port number"
+      type: 'integer'
+      default: 4242
 
   activate: (state) ->
     console.log "Activated ide-purescript"

--- a/lib/psc-ide.coffee
+++ b/lib/psc-ide.coffee
@@ -3,6 +3,7 @@
 class PscIde
   constructor: ->
     @pscIde = atom.config.get("ide-purescript.pscIdeExe")
+    @pscIdePort = atom.config.get("ide-purescript.pscIdePort")
     @getModules()
       .then (output) ->
         console.log output
@@ -10,7 +11,7 @@ class PscIde
   runCmd: (str) ->
     return new Promise (resolve,reject) =>
       command = @pscIde
-      args = []
+      args = ['-p', @pscIdePort]
       stdout = (output) =>
         console.log "psc-ide", str, "-->", output
         resolve (@trimQuote output)


### PR DESCRIPTION
On my machine, the default port 4242 is already taken by a backup service so I needed a way to customize which port the ide talks to.

I had some trouble setting this up locally, so this isn't really fully tested.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nwolverson/atom-ide-purescript/6)

<!-- Reviewable:end -->
