### PR TITLE
Basic type info tooltips based on hover-tooltips

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,7 +1,7 @@
 LinterPurescript = require './linter-purescript'
 PscIde = require './psc-ide'
-
-glob = require("glob")
+PsTooltips = require './tooltips'
+glob = require 'glob'
 
 module.exports =
   config:
@@ -29,6 +29,16 @@ module.exports =
   activate: (state) ->
     console.log "Activated ide-purescript"
     @pscide = new PscIde()
+    @tooltips = new PsTooltips(@pscide)
+    @tooltips.activate()
+
+  deactivate: () ->
+    for editor in atom.workspace.getTextEditors()
+      editorView = atom.views.getView(editor)
+      editorView.editControl?.deactivate()
+      editorView.editControl = null
+    @controlSubscription?.dispose()
+    @tooltips.deactivate()
 
   provideAutocomplete: ->
     selector: '.source.purescript'

--- a/lib/psc-ide.coffee
+++ b/lib/psc-ide.coffee
@@ -41,6 +41,12 @@ class PscIde
 
   getType: (text) ->
     @runCmd "typeLookup #{text}"
+      .then (result) =>
+        result = result.trim()
+        if result is "Not found" then "" else result
+
+  abbrevType: (type) ->
+    type.replace(/(?:\w+\.)+(\w+)/g, "$1")
 
   getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) =>
     new Promise (resolve) =>
@@ -54,7 +60,7 @@ class PscIde
             completions.forEach (c) =>
               promise = @getType c
                 .then (type) =>
-                  unqualType: type.replace(/(?:\w+\.)+(\w+)/g, "$1")
+                  unqualType: @abbrevType type
                   text: c
                   type: type
               typeProms.push promise

--- a/lib/tooltips.coffee
+++ b/lib/tooltips.coffee
@@ -1,0 +1,26 @@
+
+{ HoverTooltips } = require 'hover-tooltips';
+
+class PsTooltips extends HoverTooltips
+  constructor: (@pscIde) ->
+    super()
+    @syntax = 'source.purescript'
+    @provider = (pos) => new Promise (resolve) =>
+      p = [pos.line-1, pos.column-1]
+      buffer = atom.workspace.getActivePaneItem().buffer
+
+      regex = /[a-zA-Z_']*/
+      match = ""
+      buffer.backwardsScanInRange(regex, [[p[0], 0], p], (it) ->
+        match = it.matchText
+      )
+      buffer.scanInRange(regex, [p, [p[0], Infinity]], (it) ->
+        match += it.matchText
+      )
+
+      @pscIde.getType match
+        .then (result) =>
+          result = @pscIde.abbrevType result
+          resolve { valid: result.length > 0, info: result }
+
+module.exports = PsTooltips

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "atom-linter": "^3.0.0",
     "glob": "^5.0.14",
-    "hover-tooltips": "git://github.com/nwolverson/hover-tooltips.git#non-cmd-provider",
+    "hover-tooltips": "git://github.com/ranjitjhala/hover-tooltips.git",
     "xregexp": "~2.0.0"
   },
   "providedServices": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "atom-linter": "^3.0.0",
     "glob": "^5.0.14",
+    "hover-tooltips": "git://github.com/nwolverson/hover-tooltips.git#non-cmd-provider",
     "xregexp": "~2.0.0"
   },
   "providedServices": {


### PR DESCRIPTION
This is really dumb, just finds the token around the pointer on hover and looks up its type, regardless of it being an identifier etc.

Ideally use proper language service which one can ask for type at point which understands the language.
