### PR TITLE
Fix added whitespace to config values

### DIFF
--- a/lib/linter-purescript.coffee
+++ b/lib/linter-purescript.coffee
@@ -25,7 +25,7 @@ class LinterPurescript
         resolve([])
         return
 
-      buildCommand = atom.config.get("ide-purescript.buildCommand").split(/\s+/)
+      buildCommand = atom.config.get("ide-purescript.buildCommand").trim().split(/\s+/)
       command = buildCommand[0]
       args = buildCommand.slice(1)
 


### PR DESCRIPTION
Atom was adding whitespace to my config values at the end of the string which was breaking the build command for the linter. So I just added a trim to the output which fixes it.

Note that I didn't have a white space as an extra character in the config value, Atom was adding it.
