### PR TITLE
Use http:// instead of git:// for the hover-tooltips dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "atom-linter": "^3.0.0",
     "atom-space-pen-views": "^2.1.0",
     "glob": "^5.0.14",
-    "hover-tooltips": "git://github.com/nwolverson/hover-tooltips.git#scrolltop-removed",
+    "hover-tooltips": "git+http://github.com/nwolverson/hover-tooltips.git#scrolltop-removed",
     "xregexp": "~2.0.0"
   },
   "providedServices": {


### PR DESCRIPTION
I unfortunately work behind a firewall that blocks the port used by the `git://` protocol, but HTTP obviously works just fine. I can’t imagine any negative side effects of using HTTP for this instead, and it fixes the issue for people like me. (Normally this is possible to work around fairly easily with git settings, but [apm makes this hard](https://github.com/atom/apm/issues/106).)
