### PR TITLE
Add/remove 'ide-purescript-editor' class from TextEditors where ide-purescript is active

### DIFF
--- a/src/IdePurescript/Atom/Editor.js
+++ b/src/IdePurescript/Atom/Editor.js
@@ -1,0 +1,19 @@
+// module IdePurescript.Atom.Editor
+
+exports._addPurescriptClass = function(className) {
+  return function(editor) {
+    return function() {
+      var view = atom.views.getView(editor);
+
+      if (view.classList.contains(className))
+        return {};
+
+      view.classList.add(className);
+      editor.onDidDestroy(function() {
+        view.classList.remove(className);
+      });
+
+      return {};
+    };
+  };
+};

--- a/src/IdePurescript/Atom/Editor.purs
+++ b/src/IdePurescript/Atom/Editor.purs
@@ -6,6 +6,11 @@ import Atom.Point (Point, mkPoint, getRow, getColumn)
 import Atom.Range (Range, mkRange)
 import Control.Monad.Eff (Eff)
 
+foreign import _addPurescriptClass :: forall eff. String -> TextEditor -> Eff (editor :: EDITOR | eff) Unit
+
+addPurescriptClass :: forall eff. TextEditor -> Eff (editor :: EDITOR | eff) Unit
+addPurescriptClass = _addPurescriptClass "ide-purescript-editor"
+
 getLinePosition :: forall eff. TextEditor -> Eff (editor :: EDITOR | eff) { line :: String, col :: Int, pos :: Point, range :: Range }
 getLinePosition ed = do
   pos <- getCursorBufferPosition ed

--- a/src/IdePurescript/Atom/Main.purs
+++ b/src/IdePurescript/Atom/Main.purs
@@ -45,6 +45,7 @@ import IdePurescript.Atom.Assist (gotoDefHyper, fixTypo, addClause, caseSplit, g
 import IdePurescript.Atom.Build (AtomLintMessage)
 import IdePurescript.Atom.BuildStatus (getBuildStatus)
 import IdePurescript.Atom.Config (config)
+import IdePurescript.Atom.Editor (addPurescriptClass)
 import IdePurescript.Atom.Hooks.Dependencies (installDependencies)
 import IdePurescript.Atom.Hooks.Linter (LinterInternal, LinterIndie, LINTER, register)
 import IdePurescript.Atom.Hooks.StatusBar (addLeftTile)
@@ -84,6 +85,7 @@ getSuggestions port state ({editor, bufferPosition, activatedManually}) = Promis
 useEditor :: forall eff. Int -> (Ref State) -> TextEditor
   -> Eff (editor ::EDITOR, net :: NET, ref :: REF, console :: CONSOLE, config :: CONFIG | eff) Unit
 useEditor port modulesStateRef editor = do
+  addPurescriptClass editor
   path <- getPath editor
   when (maybe false isPursFile path) do
     text <- getText editor


### PR DESCRIPTION
Fix #150 by adding the `ide-purescript-editor` class to the editor when `ide-purescript` is activated and removing this class when the editor is destroyed.

> The `main.js` bundle is not provided in this PR as the diff was too large, maybe because the compiler versions used didn't match.